### PR TITLE
Only call self.get_data() once for generating Line Chart (fixes #16)

### DIFF
--- a/chartjs/views/__init__.py
+++ b/chartjs/views/__init__.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 from six import text_type
 from ..colors import next_color
 from .base import JSONView

--- a/chartjs/views/lines.py
+++ b/chartjs/views/lines.py
@@ -23,13 +23,13 @@ class BaseLineChartView(JSONView):
         data = self.get_data()
         providers = self.get_providers()
         num = len(providers)
-        for i, data in enumerate(self.get_data()):
+        for i, entry in enumerate(data):
             color = tuple(next(color_generator))
             dataset = {'fillColor': "rgba(%d, %d, %d, 0.5)" % color,
                        'strokeColor': "rgba(%d, %d, %d, 1)" % color,
                        'pointColor': "rgba(%d, %d, %d, 1)" % color,
                        'pointStrokeColor': "#fff",
-                       'data': data}
+                       'data': entry}
             if i < num:
                 dataset['name'] = providers[i]
             datasets.append(dataset)


### PR DESCRIPTION
This avoids loading from the database more than once for generating a line chart.