### PR TITLE
ref #23 - Upgrade django-chartjs to python35 and Django 1.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
-    - "2.7"
-    - "3.3"
+    - "3.5"
+before_install:
+    - pip install -U pip setuptools
+    - pip install -U tox
 install:
     - pip install -r test-requirements.pip
-    - python setup.py develop
-    - (cd demo; python setup.py develop)
-script: flake8 chartjs && demo test demoproject
+script: tox
 after_success:
   # Report coverage results to coveralls.io
   - pip install coveralls

--- a/demo/demoproject/settings.py
+++ b/demo/demoproject/settings.py
@@ -4,6 +4,7 @@ from os.path import abspath, dirname, join
 
 # Configure some relative directories.
 demoproject_dir = dirname(abspath(__file__))
+BASE_DIR = demoproject_dir
 demo_dir = dirname(demoproject_dir)
 root_dir = dirname(demo_dir)
 data_dir = join(root_dir, 'var')
@@ -49,15 +50,32 @@ INSTALLED_APPS = (
     'django_nose',
 )
 
+USE_I18N = False
+
 TEMPLATE_CONTEXT_PROCESSORS = [
     "django.contrib.auth.context_processors.auth",
     "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
     "django.core.context_processors.media",
     "django.core.context_processors.static",
     "django.core.context_processors.tz",
     "django.contrib.messages.context_processors.messages",
     "django.core.context_processors.request",
+]
+
+TEMPLATES = [{
+    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    'DIRS': [join(BASE_DIR, '', 'templates')],
+    'APP_DIRS': True,
+    'OPTIONS': {
+        'context_processors': [
+            'django.template.context_processors.debug',
+            'django.template.context_processors.request',
+            'django.contrib.auth.context_processors.auth',
+            'django.contrib.messages.context_processors.messages',
+
+        ],
+    },
+},
 ]
 
 # Default middlewares. You may alter the list later.

--- a/demo/demoproject/urls.py
+++ b/demo/demoproject/urls.py
@@ -1,12 +1,17 @@
-from django.conf.urls import patterns, url
+from pkg_resources import parse_version
+import django
+from django.conf.urls import url
+django_version = parse_version(django.get_version())
+if django_version <= parse_version('1.9'):
+    from django.conf.urls import patterns
+
 from django.views.generic import TemplateView
 
 from . import views
 
 home = TemplateView.as_view(template_name='home.html')
 
-urlpatterns = patterns(
-    '',
+patterns_list = [
     url(r'^$', home, name='home'),
     url(r'^colors/$', views.colors, name='colors'),
 
@@ -27,4 +32,12 @@ urlpatterns = patterns(
         name='pie_highchart_json'),
     url(r'^donut_highchart/json/$', views.donut_highchart_json,
         name='donut_highchart_json'),
-)
+]
+
+if django_version <= parse_version('1.9'):
+    urlpatterns = patterns(
+        '',
+        *patterns_list
+    )
+else:
+    urlpatterns = patterns_list

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
         classifiers=['Development Status :: 4 - Beta',
                      'Environment :: Web Environment',
                      'Framework :: Django',
+                     'Framework :: Django :: 1.10',
+                     'Framework :: Django :: 1.8',
+                     'Framework :: Django :: 1.9',
                      'Intended Audience :: Developers',
                      'License :: OSI Approved :: BSD License',
                      'Programming Language :: Python',
@@ -33,5 +36,5 @@ if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
         packages=find_packages(),
         include_package_data=True,
         zip_safe=False,
-        install_requires=['six']  # depends on Django
+        install_requires=['six']
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,11 @@
 [tox]
-envlist = py27,py33
+envlist = django{18,19,110}-py{27,34,35}
 
 [testenv]
+deps =
+	django18: Django>=1.8,<1.9
+	django19: Django>=1.9,<1.10
+	django110: Django>=1.10,<1.11
 commands =
     pip install -r test-requirements.pip
     pip install -e ./


### PR DESCRIPTION
### Upgrade support to python 2.7 + 3.4 + 3.5, on Django 1.8 + 1.9 and 1.10

ref #23 

- [x] change tox.ini
- [x] change .travis.yml
- [x] update demoproject and settings in order to unit tests to pass
- [ ] need to do a new release or release on PyPi for python3 ?